### PR TITLE
Update screwdriver.yaml

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -73,7 +73,7 @@ jobs:
     requires: [publish_sd_cmd]
 
   test_sd_cmd_ubuntu:
-    image: ubuntu:18.04
+    image: ubuntu
     steps:
       - testpypirun: sd-cmd python/pypirun@pre serviceping serviceping -c 1 yahoo.com
     requires: [publish_sd_cmd]


### PR DESCRIPTION
Change the test_sd_cmd_ubuntu image since the one specified was causing a ci/cd hang

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
