### PR TITLE
Add a --upgrade_pip flag to upgrade pip before installing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ $ pip install pypirun
       --interpreter INTERPRETER  Python interpreter to use
       --debug                    Enable debug output
       --always_install           Install the command even if it exists in the path
+      --upgrade_pip              Upgrade the pip before installing packages
+      --upgrade_setuptools       Upgrade setuptools before installing packages
     
     Everything on the command line after the package name is executed in an environment with the package installed and on 
     the PATH.  As a result, the package and command must come after the optional arguments.

--- a/src/pypirun/arguments.py
+++ b/src/pypirun/arguments.py
@@ -38,7 +38,8 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument('--debug', default=debug, action='store_true', help='Enable debug output')
     parser.add_argument('--always_install', default=False, action='store_true', help='Install the command even if it exists in the path')
     parser.add_argument('--no-cache-dir', default=False, action='store_true', help="Disable the pip cache when installing")
-    parser.add_argument('--upgrade_setuptools', default=False, action='store_true', help="Upgrade setuptools before installing")
+    parser.add_argument('--upgrade_pip', default=False, action='store_true', help='Upgrade the pip before installing packages')
+    parser.add_argument('--upgrade_setuptools', default=False, action='store_true', help="Upgrade setuptools before installing packages")
     parser.add_argument('package', type=str, help='Package the command is in')
     parser.add_argument('command', nargs='*', help='Command to run')
 

--- a/src/pypirun/cli.py
+++ b/src/pypirun/cli.py
@@ -34,7 +34,7 @@ def interpreter_parent(interpreter):
         real_prefix = subprocess.check_output([interpreter, '-c', 'import sys;print(sys.real_prefix)'], stderr=subprocess.DEVNULL).decode(errors='ignore').strip()  # nosec
     except subprocess.CalledProcessError:  # pragma: no cover
         return interpreter
-    try:
+    try:  # pragma: no cover
         major_minor = subprocess.check_output([interpreter, '-c', 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")'], stderr=subprocess.DEVNULL).decode(errors='ignore').strip()  # nosec
         basename = f'python{major_minor}'
     except subprocess.CalledProcessError:  # pragma: no cover
@@ -45,7 +45,7 @@ def interpreter_parent(interpreter):
     return interpreter
 
 
-def install_and_run(package, command, interpreter, debug=False, no_cache_dir=False, upgrade_setuptools=False):
+def install_and_run(package, command, interpreter, debug=False, no_cache_dir=False, upgrade_setuptools=False, upgrade_pip=False):
     """
     Install a package and run a command in a temporary Python virtualenv
     
@@ -68,6 +68,9 @@ def install_and_run(package, command, interpreter, debug=False, no_cache_dir=Fal
     
     upgrade_setuptools: bool, optional
         Upgrade setuptools after creating the virtualenv but before installing packages.  Default: False
+
+    upgrade_pip: bool, optional
+        Upgrade pip after creating the virtualenv but before installing packages.  Default: False
     """
     packages = package.split(',')
 
@@ -93,6 +96,11 @@ def install_and_run(package, command, interpreter, debug=False, no_cache_dir=Fal
 
         if not os.path.exists(venv_pip):  # pragma: no cover
             output = subprocess.check_output([venv_python, '-m', 'pip', 'install', '--force-reinstall'] + pip_args + ['pip'], stderr=subprocess.STDOUT)  # nosec
+            if debug:  # pragma: no cover
+                print(output.decode())
+
+        if upgrade_pip:  # pragma: no cover
+            output = subprocess.check_output([venv_pip, 'install', '--upgrade'] + pip_args + ['pip'], stderr=subprocess.STDOUT)  # nosec
             if debug:  # pragma: no cover
                 print(output.decode())
 
@@ -154,7 +162,7 @@ def main():
         return 1
 
     if args.always_install or not shutil.which(command_file):
-        return install_and_run(package=args.package, command=command, interpreter=interpreter, debug=args.debug, no_cache_dir=args.no_cache_dir, upgrade_setuptools=args.upgrade_setuptools)
+        return install_and_run(package=args.package, command=command, interpreter=interpreter, debug=args.debug, no_cache_dir=args.no_cache_dir, upgrade_setuptools=args.upgrade_setuptools, upgrade_pip=args.upgrade_pip)
 
     try:
         subprocess.check_call(command, shell=True)  # nosec

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -35,5 +35,7 @@ class TestArguments(unittest.TestCase):
         self.assertEqual(result.interpreter, default_interpreter)
         self.assertFalse(result.debug)
         self.assertFalse(result.always_install)
+        self.assertFalse(result.upgrade_pip)
+        self.assertFalse(result.upgrade_setuptools)
         self.assertEqual(result.package, 'foo')
         self.assertEqual(result.command, ['bar'])


### PR DESCRIPTION
This is to address #16 it adds a flag to upgrade pip in the venv before installing packages.

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
