### PR TITLE
Add flag to interpreter the command as a module passed as the `-m` flag to the interpreter running the command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ from yahoo.com:80 (72.30.35.10:80): time=65.50 ms                               
 rtt min/avg/max/dev = 65.50/65.50/65.50/0.00 ms
 ```
 
+### Run the serviceping module from the serviceping package as a script
+
+```
+```
+
 ## Screwdriver V4 pypirun command
 
 The pypirun package publishes a screwdriver v4 shared command called `python/pypirun`.

--- a/README.md
+++ b/README.md
@@ -69,16 +69,18 @@ $ pip install pypirun
 The following will run the command `serviceping -c 1 yahoo.com` from the [serviceping](https://pypi.org/project/serviceping/) package:
 
 ```console
-dhubbard@mac:~$ pypirun serviceping serviceping -c 1 yahoo.com
+$ pypirun serviceping serviceping -c 1 yahoo.com
 SERVICEPING yahoo.com:80 (72.30.35.10:80).
 from yahoo.com:80 (72.30.35.10:80): time=65.50 ms                                                                                                                                                                                                                 --- yahoo.com ping statistics ---
 1 packages transmitted, 1 received, 0.0% package loss, time 73.038ms
 rtt min/avg/max/dev = 65.50/65.50/65.50/0.00 ms
 ```
 
-### Run the serviceping module from the serviceping package as a script
+### Run the screwdrivercd.installdeps module from the screwdrivercd package as a script
 
-```
+```console
+$ pypirun -m screwdrivercd screwdrivercd.installdeps
+$
 ```
 
 ## Screwdriver V4 pypirun command

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -2,6 +2,7 @@ version: 4
 shared:
   environment:
     PACKAGE_DIRECTORY: src
+    TOX_ENVLIST: py39,py310,py311
     
 jobs:
   validate_test:

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages=
 package_dir=
     =src
 
-python_requires = >= 3.8
+python_requires = >= 3.9
 zip_safe = True
 
 [options.entry_points]

--- a/src/pypirun/arguments.py
+++ b/src/pypirun/arguments.py
@@ -52,7 +52,7 @@ def parse_arguments() -> argparse.Namespace:
     command = []
     in_command = False
     for argument in sys.argv[1:]:
-        if not in_command and argument.startswith('--'):
+        if not in_command and argument.startswith('-'):
             argv.append(argument)
             continue
         in_command = True
@@ -65,6 +65,11 @@ def parse_arguments() -> argparse.Namespace:
         raise ParseError('Insufficient arguments provided')
 
     args = parser.parse_args(args=argv)
+
     args.package = command[0]
-    args.command = command[1:]
+    if args.module:
+        args.module = command[1]
+        args.command = command[2:]
+    else:
+        args.command = command[1:]
     return args

--- a/src/pypirun/arguments.py
+++ b/src/pypirun/arguments.py
@@ -40,6 +40,7 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument('--no-cache-dir', default=False, action='store_true', help="Disable the pip cache when installing")
     parser.add_argument('--upgrade_pip', default=False, action='store_true', help='Upgrade the pip before installing packages')
     parser.add_argument('--upgrade_setuptools', default=False, action='store_true', help="Upgrade setuptools before installing packages")
+    parser.add_argument('--module', '-m', default=False, action='store_true', help='Run library module as a script')
     parser.add_argument('package', type=str, help='Package the command is in')
     parser.add_argument('command', nargs='*', help='Command to run')
 
@@ -66,5 +67,4 @@ def parse_arguments() -> argparse.Namespace:
     args = parser.parse_args(args=argv)
     args.package = command[0]
     args.command = command[1:]
-
     return args

--- a/src/pypirun/cli.py
+++ b/src/pypirun/cli.py
@@ -45,7 +45,7 @@ def interpreter_parent(interpreter):
     return interpreter
 
 
-def install_and_run(package, command, interpreter, debug=False, no_cache_dir=False, upgrade_setuptools=False, upgrade_pip=False):
+def install_and_run(package, command, interpreter, module='', debug=False, no_cache_dir=False, upgrade_setuptools=False, upgrade_pip=False):
     """
     Install a package and run a command in a temporary Python virtualenv
     
@@ -59,7 +59,10 @@ def install_and_run(package, command, interpreter, debug=False, no_cache_dir=Fal
         
     interpreter: str
         The python interpreter executable to use to create the virtualenv
-    
+
+    module: str
+        Python module for the interpreter to run
+
     debug: bool, optional
         Print more useful debug output.  Default: False
     
@@ -125,10 +128,16 @@ def install_and_run(package, command, interpreter, debug=False, no_cache_dir=Fal
             print(f'Installed files: {list(venv_bin_after-venv_bin_before)}')
 
         # Run the command
-        try:
-            subprocess.check_call(f'{venv_dir}/bin/{command}', shell=True)  # nosec
-        except subprocess.CalledProcessError as error:  # pragma: no cover
-            return error.returncode
+        if module:
+            try:
+                subprocess.check_call(f'{venv_dir}/bin/python3 -m {command}', shell=True)  # nosec
+            except subprocess.CalledProcessError as error:  # pragma: no cover
+                return error.returncode
+        else:
+            try:
+                subprocess.check_call(f'{venv_dir}/bin/{command}', shell=True)  # nosec
+            except subprocess.CalledProcessError as error:  # pragma: no cover
+                return error.returncode
         return exit_ok()  # pragma: no cover
 
 
@@ -162,10 +171,18 @@ def main():
         return 1
 
     if args.always_install or not shutil.which(command_file):
-        return install_and_run(package=args.package, command=command, interpreter=interpreter, debug=args.debug, no_cache_dir=args.no_cache_dir, upgrade_setuptools=args.upgrade_setuptools, upgrade_pip=args.upgrade_pip)
+        return install_and_run(package=args.package, command=command, interpreter=interpreter, module=args.module, debug=args.debug, no_cache_dir=args.no_cache_dir, upgrade_setuptools=args.upgrade_setuptools, upgrade_pip=args.upgrade_pip)
 
-    try:
-        subprocess.check_call(command, shell=True)  # nosec
-    except subprocess.CalledProcessError as error:
-        return error.returncode
+    if args.module:
+        new_command = f'{interpreter} -m {command}'
+        print(f'Running: {new_command}')
+        try:
+            subprocess.check_call(new_command, shell=True)  # nosec
+        except subprocess.CalledProcessError as error:
+            return error.returncode
+    else:
+        try:
+            subprocess.check_call(command, shell=True)  # nosec
+        except subprocess.CalledProcessError as error:
+            return error.returncode
     return 0  # pragma: no cover

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -39,3 +39,17 @@ class TestArguments(unittest.TestCase):
         self.assertFalse(result.upgrade_setuptools)
         self.assertEqual(result.package, 'foo')
         self.assertEqual(result.command, ['bar'])
+
+    def test_parse_arguments_module(self):
+        sys.argv = ['parse_arguments', '-m', 'foo', 'bar']
+        default_interpreter = os.environ.get('BASE_PYTHON', None)
+        result = pypirun.arguments.parse_arguments()
+        self.assertIsInstance(result, argparse.Namespace)
+        self.assertEqual(result.interpreter, default_interpreter)
+        self.assertFalse(result.debug)
+        self.assertFalse(result.always_install)
+        self.assertFalse(result.upgrade_pip)
+        self.assertFalse(result.upgrade_setuptools)
+        self.assertEqual(result.module, 'bar')
+        self.assertEqual(result.package, 'foo')
+        self.assertEqual(result.command, [])

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ package_dir = src/pypirun
 package_name = pypirun
 
 [tox]
-envlist = py38,py39,py310,py311
+envlist = py39,py310,py311
 isolated_build = True
 skip_missing_interpreters = true
 


### PR DESCRIPTION
## Motivation and Context
To allow running code in modules instead of only scripts.

This adds a flag `--module` or `-m` that flags the first element of the command as a python module name that will be executed using `interpreter -m {module} {args}` instead of a script.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
